### PR TITLE
Corrección en el Evento "Cápsulas de carga" OJO (No confundir con Cáp…

### DIFF
--- a/Keyed/Incidents.xml
+++ b/Keyed/Incidents.xml
@@ -42,7 +42,7 @@
   <!-- EN: Cargo pods -->
   <LetterLabelCargoPodCrash>Cápsulas de carga</LetterLabelCargoPodCrash>
   <!-- EN: You have detected a cluster of cargo pods crashing nearby.\n\nPerhaps you'll find something useful in the wreckage. -->
-  <CargoPodCrash>Hemos detectado un grupo de cápsulas de carga estrellándose en las cercanías.\n\nSi cualquier persona ha sobrevivido al impacto, estara gravemente herido(a).\n\nPodras rescatarlos y enviarles por su camino, o capturarlos con fines de reclutamiento o esclavitud.</CargoPodCrash>
+  <CargoPodCrash>Hemos detectado un grupo de cápsulas de carga estrellándose en las cercanías.\n\nPuede que encuentres algo útil en los restos.</CargoPodCrash>
 
   <!-- EN: an electrical conduit -->
   <AnElectricalConduit>un cortocircuito eléctrico</AnElectricalConduit>


### PR DESCRIPTION
…sula de Escape)

Arreglo de un error en la traducción el el cual, los textos en español para los eventos de las lineas 
31   <!-- EN: Transport pod crash --> y  42 <!-- EN: Cargo pods -->
Son exactamente los mismo, cuando en su texto inglés no es así.
Veáse lineas 31 y 42
Se ha traducido el evento de su versión inglesa de la forma mas fiel posible, esperando que el visto bueno de su parte.
Solo quiero contribuir arreglando pequeños errores que pueda encontrar mientras juego.
Gracias por su trabajo.